### PR TITLE
[PFCMP-0010] Network Failure View #98

### DIFF
--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
@@ -1,0 +1,107 @@
+//
+//  NetworkFailureView.swift
+//  Component
+//
+//  Created by Evan Christian on 16/11/20.
+//
+
+import UIKit
+public protocol NetworkFailureDelegate: class {
+    func didTapButton(sender: UIButton)
+}
+
+public class NetworkFailureView: UIView {
+    // MARK: - IBOutlet
+    @IBOutlet var networkFailureView: UIView!
+    @IBOutlet weak var networkFailureViewContainer: UIView!
+    @IBOutlet weak var imageViewContainer: UIView!
+    @IBOutlet weak var labelContainer: UIView!
+    @IBOutlet weak var buttonContainer: UIView!
+    @IBOutlet weak var networkFailureImageView: UIImageView!
+    @IBOutlet weak var networkFailureLabel: UILabel!{
+        didSet {
+            networkFailureLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
+                                     size: FamiliAlertViewConstant.CommonValue.fontSizeTitle)
+        }
+    }
+    @IBOutlet weak var networkFailureButton: UIButton!{
+        didSet {
+            networkFailureButton.backgroundColor = UIColor(hex: FamiliAlertViewConstant.CommonColor.primary.rawValue)
+            networkFailureButton.layer.cornerRadius = FamiliAlertViewConstant.CommonValue.cornerRadius
+            networkFailureButton.titleLabel?.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
+                                                    size: FamiliAlertViewConstant.CommonValue.fontSizeButton)
+            networkFailureButton.tintColor = .white
+            networkFailureButton.setTitle(FamiliAlertViewConstant.CommonString.okButton.rawValue, for: .normal)
+        }
+    }
+    
+    weak public var networkFailureDelegate: NetworkFailureDelegate?
+
+    // MARK: - Initialization
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+    
+    // MARK: - Handler
+    /// Calls the delegate to handle action button tapped
+    @objc func buttonTapped(_ sender: UIButton) {
+        networkFailureDelegate?.didTapButton(sender: sender)
+    }
+    
+    // MARK: - Function
+    /// setup the base, container, and button
+    private func setupView() {
+        baseViewSetup()
+        setupContainerView()
+        setupButton()
+    }
+    
+    /// setup base bundle and layer styling
+    private func baseViewSetup() {
+        let bundle = Bundle(for: NetworkFailureView.self)
+        bundle.loadNibNamed(String(describing: NetworkFailureView.self), owner: self, options: nil)
+        networkFailureView.frame = self.bounds
+        networkFailureView.alpha = 1
+        networkFailureView.backgroundColor = .clear
+        networkFailureView.autoresizingMask = [.flexibleHeight, .flexibleHeight]
+    }
+    /// setup button target action
+    private func setupButton() {
+        networkFailureButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+    }
+    
+    /// setup container styling
+    private func setupContainerView() {
+        networkFailureViewContainer.layer.backgroundColor = UIColor.white.cgColor
+        networkFailureViewContainer.layer.shadowOffset = .init(width: 0, height: 2)
+        networkFailureViewContainer.layer.shadowOpacity = 1
+    }
+
+    // MARK: - Public Function
+    /**
+    Provide alert view to the current controller that contains description, and button
+    
+    - Parameters:
+        - image: the file name of the image that you want to show. The default value is "" meaning no image.
+        - description: description of the alert
+        - buttonTitle: title for action button
+        - view: the parent view for alertView
+    */
+    public func displayNetworkFailureView(image: UIImage? = nil, description: String, buttonTItle: String,to view: UIView) {
+        networkFailureImageView.image = image
+        networkFailureLabel.text = description
+        networkFailureButton.setTitle(buttonTItle, for: .normal)
+        view.addSubview(networkFailureView)
+    }
+    
+    /// remove alertView from its parent
+    public func dismissNetworkFailureView() {
+        self.removeFromSuperview()
+    }
+}

--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
@@ -110,7 +110,6 @@ public class NetworkFailureView: UIView {
         networkFailureDescriptionLabel.text = description
         networkFailureButton.setTitle(buttonTItle, for: .normal)
         networkFailureView.sizeToFit()
-//        networkFailureView.center = CGPoint(x: view.bounds.size.width / 2, y: view.bounds.size.height / 2)
         networkFailureView.center = view.convert(view.center, from: view.superview)
         view.addSubview(networkFailureView)
     }

--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
@@ -15,12 +15,19 @@ public class NetworkFailureView: UIView {
     @IBOutlet var networkFailureView: UIView!
     @IBOutlet weak var networkFailureViewContainer: UIView!
     @IBOutlet weak var imageViewContainer: UIView!
-    @IBOutlet weak var labelContainer: UIView!
+    @IBOutlet weak var titleLabelContainer: UIView!
+    @IBOutlet weak var descriptionLabelContainer: UIView!
     @IBOutlet weak var buttonContainer: UIView!
     @IBOutlet weak var networkFailureImageView: UIImageView!
-    @IBOutlet weak var networkFailureLabel: UILabel!{
+    @IBOutlet weak var networkFailureTitleLabel: UILabel!{
         didSet {
-            networkFailureLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
+            networkFailureTitleLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
+                                     size: FamiliAlertViewConstant.CommonValue.fontSizeTitle)
+        }
+    }
+    @IBOutlet weak var networkFailureDescriptionLabel: UILabel!{
+        didSet {
+            networkFailureDescriptionLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
                                      size: FamiliAlertViewConstant.CommonValue.fontSizeTitle)
         }
     }
@@ -89,14 +96,22 @@ public class NetworkFailureView: UIView {
     
     - Parameters:
         - image: the file name of the image that you want to show. The default value is "" meaning no image.
+        - title: title of the alert
         - description: description of the alert
         - buttonTitle: title for action button
         - view: the parent view for alertView
     */
-    public func displayNetworkFailureView(image: UIImage? = nil, description: String, buttonTItle: String,to view: UIView) {
+    public func displayNetworkFailureView(image: UIImage? = nil, title: String, description: String, buttonTItle: String,to view: UIView) {
         networkFailureImageView.image = image
-        networkFailureLabel.text = description
+        if image == nil {
+            imageViewContainer.isHidden = true
+        }
+        networkFailureTitleLabel.text = title
+        networkFailureDescriptionLabel.text = description
         networkFailureButton.setTitle(buttonTItle, for: .normal)
+        networkFailureView.sizeToFit()
+//        networkFailureView.center = CGPoint(x: view.bounds.size.width / 2, y: view.bounds.size.height / 2)
+        networkFailureView.center = view.convert(view.center, from: view.superview)
         view.addSubview(networkFailureView)
     }
     

--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.swift
@@ -19,19 +19,19 @@ public class NetworkFailureView: UIView {
     @IBOutlet weak var descriptionLabelContainer: UIView!
     @IBOutlet weak var buttonContainer: UIView!
     @IBOutlet weak var networkFailureImageView: UIImageView!
-    @IBOutlet weak var networkFailureTitleLabel: UILabel!{
+    @IBOutlet weak var networkFailureTitleLabel: UILabel! {
         didSet {
             networkFailureTitleLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
                                      size: FamiliAlertViewConstant.CommonValue.fontSizeTitle)
         }
     }
-    @IBOutlet weak var networkFailureDescriptionLabel: UILabel!{
+    @IBOutlet weak var networkFailureDescriptionLabel: UILabel! {
         didSet {
             networkFailureDescriptionLabel.font = UIFont(name: FamiliAlertViewConstant.CommonValue.fontFamilySemiBold,
                                      size: FamiliAlertViewConstant.CommonValue.fontSizeTitle)
         }
     }
-    @IBOutlet weak var networkFailureButton: UIButton!{
+    @IBOutlet weak var networkFailureButton: UIButton! {
         didSet {
             networkFailureButton.backgroundColor = UIColor(hex: FamiliAlertViewConstant.CommonColor.primary.rawValue)
             networkFailureButton.layer.cornerRadius = FamiliAlertViewConstant.CommonValue.cornerRadius

--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.xib
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.xib
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NetworkFailureView" customModule="Component" customModuleProvider="target">
+            <connections>
+                <outlet property="buttonContainer" destination="YMG-ht-AdU" id="xVa-i3-Jh3"/>
+                <outlet property="imageViewContainer" destination="lft-y5-fF9" id="nnc-6J-ULJ"/>
+                <outlet property="labelContainer" destination="8uc-te-5Iv" id="ucR-DB-Baq"/>
+                <outlet property="networkFailureButton" destination="g6b-oT-zeV" id="0ld-YF-Yuf"/>
+                <outlet property="networkFailureImageView" destination="ZoD-cx-edW" id="cOf-8H-X5z"/>
+                <outlet property="networkFailureLabel" destination="sWC-gV-Jil" id="do4-eI-2Nf"/>
+                <outlet property="networkFailureView" destination="iN0-l3-epB" id="Jws-Im-0EY"/>
+                <outlet property="networkFailureViewContainer" destination="HSl-E2-Lx2" id="nE5-Ds-SjE"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HSl-E2-Lx2">
+                    <rect key="frame" x="57" y="241" width="300" height="424"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="QSX-Xe-hid">
+                            <rect key="frame" x="0.0" y="0.0" width="300" height="424"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lft-y5-fF9" userLabel="Image View Container">
+                                    <rect key="frame" x="0.0" y="0.0" width="300" height="130"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZoD-cx-edW">
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="130"/>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="130" id="91f-ho-AxN"/>
+                                        <constraint firstAttribute="trailing" secondItem="ZoD-cx-edW" secondAttribute="trailing" id="dVF-Ug-MLp"/>
+                                        <constraint firstAttribute="bottom" secondItem="ZoD-cx-edW" secondAttribute="bottom" id="gTy-eT-aTl"/>
+                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="leading" secondItem="lft-y5-fF9" secondAttribute="leading" id="iMW-qg-aT9"/>
+                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="top" secondItem="lft-y5-fF9" secondAttribute="top" id="qqE-ra-yo1"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8uc-te-5Iv" userLabel="Label Container">
+                                    <rect key="frame" x="0.0" y="132" width="300" height="240"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWC-gV-Jil">
+                                            <rect key="frame" x="8" y="8" width="284" height="224"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="240" id="F4c-6K-5hS"/>
+                                        <constraint firstAttribute="trailing" secondItem="sWC-gV-Jil" secondAttribute="trailing" constant="8" id="Wk2-a6-lFU"/>
+                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="top" secondItem="8uc-te-5Iv" secondAttribute="top" constant="8" id="aUX-8C-WEt"/>
+                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="leading" secondItem="8uc-te-5Iv" secondAttribute="leading" constant="8" id="jEG-kj-i41"/>
+                                        <constraint firstAttribute="bottom" secondItem="sWC-gV-Jil" secondAttribute="bottom" constant="8" id="xXA-Ew-kFH"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YMG-ht-AdU" userLabel="Button Container">
+                                    <rect key="frame" x="0.0" y="374" width="300" height="50"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6b-oT-zeV">
+                                            <rect key="frame" x="8" y="10" width="284" height="30"/>
+                                            <state key="normal" title="Button"/>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="JZv-Z5-qWf"/>
+                                        <constraint firstAttribute="trailing" secondItem="g6b-oT-zeV" secondAttribute="trailing" constant="8" id="PNQ-me-26f"/>
+                                        <constraint firstAttribute="bottom" secondItem="g6b-oT-zeV" secondAttribute="bottom" constant="10" id="Zk2-wn-QFk"/>
+                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="leading" secondItem="YMG-ht-AdU" secondAttribute="leading" constant="8" id="fPm-Vv-2hy"/>
+                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="top" secondItem="YMG-ht-AdU" secondAttribute="top" constant="10" id="oh1-oY-REt"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstItem="QSX-Xe-hid" firstAttribute="leading" secondItem="HSl-E2-Lx2" secondAttribute="leading" id="145-UB-IhO"/>
+                        <constraint firstAttribute="width" constant="300" id="5xq-tk-xuo"/>
+                        <constraint firstAttribute="height" constant="424" id="6oi-v9-CJg"/>
+                        <constraint firstAttribute="trailing" secondItem="QSX-Xe-hid" secondAttribute="trailing" id="GdS-cE-fBo"/>
+                        <constraint firstAttribute="bottom" secondItem="QSX-Xe-hid" secondAttribute="bottom" id="V2V-7f-13C"/>
+                        <constraint firstItem="QSX-Xe-hid" firstAttribute="top" secondItem="HSl-E2-Lx2" secondAttribute="top" id="ley-2M-VPK"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="GbC-AJ-0QG"/>
+                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="Sjr-0c-vMZ"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="137.68115942028987" y="110.49107142857143"/>
+        </view>
+    </objects>
+</document>

--- a/Component/Component/View/NetworkFailureView/NetworkFailureView.xib
+++ b/Component/Component/View/NetworkFailureView/NetworkFailureView.xib
@@ -10,13 +10,15 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NetworkFailureView" customModule="Component" customModuleProvider="target">
             <connections>
                 <outlet property="buttonContainer" destination="YMG-ht-AdU" id="xVa-i3-Jh3"/>
+                <outlet property="descriptionLabelContainer" destination="8uc-te-5Iv" id="fSm-aw-0aV"/>
                 <outlet property="imageViewContainer" destination="lft-y5-fF9" id="nnc-6J-ULJ"/>
-                <outlet property="labelContainer" destination="8uc-te-5Iv" id="ucR-DB-Baq"/>
                 <outlet property="networkFailureButton" destination="g6b-oT-zeV" id="0ld-YF-Yuf"/>
+                <outlet property="networkFailureDescriptionLabel" destination="sWC-gV-Jil" id="okX-g8-RZX"/>
                 <outlet property="networkFailureImageView" destination="ZoD-cx-edW" id="cOf-8H-X5z"/>
-                <outlet property="networkFailureLabel" destination="sWC-gV-Jil" id="do4-eI-2Nf"/>
+                <outlet property="networkFailureTitleLabel" destination="hg5-jv-T4m" id="HZI-Vi-dOI"/>
                 <outlet property="networkFailureView" destination="iN0-l3-epB" id="Jws-Im-0EY"/>
                 <outlet property="networkFailureViewContainer" destination="HSl-E2-Lx2" id="nE5-Ds-SjE"/>
+                <outlet property="titleLabelContainer" destination="3z2-kH-wFO" id="80p-p1-jsY"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -25,10 +27,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HSl-E2-Lx2">
-                    <rect key="frame" x="57" y="241" width="300" height="424"/>
+                    <rect key="frame" x="57" y="263.5" width="300" height="369"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="QSX-Xe-hid">
-                            <rect key="frame" x="0.0" y="0.0" width="300" height="424"/>
+                            <rect key="frame" x="0.0" y="20" width="300" height="329"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lft-y5-fF9" userLabel="Image View Container">
                                     <rect key="frame" x="0.0" y="0.0" width="300" height="130"/>
@@ -39,18 +41,18 @@
                                     </subviews>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="130" id="91f-ho-AxN"/>
-                                        <constraint firstAttribute="trailing" secondItem="ZoD-cx-edW" secondAttribute="trailing" id="dVF-Ug-MLp"/>
-                                        <constraint firstAttribute="bottom" secondItem="ZoD-cx-edW" secondAttribute="bottom" id="gTy-eT-aTl"/>
-                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="leading" secondItem="lft-y5-fF9" secondAttribute="leading" id="iMW-qg-aT9"/>
-                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="top" secondItem="lft-y5-fF9" secondAttribute="top" id="qqE-ra-yo1"/>
+                                        <constraint firstAttribute="bottom" secondItem="ZoD-cx-edW" secondAttribute="bottom" id="0mX-EK-Mg8"/>
+                                        <constraint firstAttribute="trailing" secondItem="ZoD-cx-edW" secondAttribute="trailing" id="VJg-N9-reV"/>
+                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="top" secondItem="lft-y5-fF9" secondAttribute="top" id="hwm-dG-FrO"/>
+                                        <constraint firstItem="ZoD-cx-edW" firstAttribute="leading" secondItem="lft-y5-fF9" secondAttribute="leading" id="sw2-U4-LMy"/>
+                                        <constraint firstAttribute="height" constant="130" id="yk1-N5-9hi"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8uc-te-5Iv" userLabel="Label Container">
-                                    <rect key="frame" x="0.0" y="132" width="300" height="240"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3z2-kH-wFO" userLabel="Title Label Container">
+                                    <rect key="frame" x="0.0" y="132" width="300" height="50"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWC-gV-Jil">
-                                            <rect key="frame" x="8" y="8" width="284" height="224"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hg5-jv-T4m">
+                                            <rect key="frame" x="0.0" y="4" width="300" height="46"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -58,28 +60,47 @@
                                     </subviews>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="240" id="F4c-6K-5hS"/>
-                                        <constraint firstAttribute="trailing" secondItem="sWC-gV-Jil" secondAttribute="trailing" constant="8" id="Wk2-a6-lFU"/>
-                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="top" secondItem="8uc-te-5Iv" secondAttribute="top" constant="8" id="aUX-8C-WEt"/>
-                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="leading" secondItem="8uc-te-5Iv" secondAttribute="leading" constant="8" id="jEG-kj-i41"/>
-                                        <constraint firstAttribute="bottom" secondItem="sWC-gV-Jil" secondAttribute="bottom" constant="8" id="xXA-Ew-kFH"/>
+                                        <constraint firstAttribute="bottom" secondItem="hg5-jv-T4m" secondAttribute="bottom" id="Xiu-TU-npm"/>
+                                        <constraint firstAttribute="trailing" secondItem="hg5-jv-T4m" secondAttribute="trailing" id="kAe-nX-8Lc"/>
+                                        <constraint firstItem="hg5-jv-T4m" firstAttribute="leading" secondItem="3z2-kH-wFO" secondAttribute="leading" id="pOZ-x2-jqI"/>
+                                        <constraint firstAttribute="height" constant="50" id="tkx-Rk-4iW"/>
+                                        <constraint firstItem="hg5-jv-T4m" firstAttribute="top" secondItem="3z2-kH-wFO" secondAttribute="top" constant="4" id="wPV-vy-beA"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8uc-te-5Iv" userLabel="Label Container">
+                                    <rect key="frame" x="0.0" y="184" width="300" height="93"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWC-gV-Jil">
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="93"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="93" id="8TN-ZC-gfB"/>
+                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="top" secondItem="8uc-te-5Iv" secondAttribute="top" id="9v1-JS-RZE"/>
+                                        <constraint firstItem="sWC-gV-Jil" firstAttribute="leading" secondItem="8uc-te-5Iv" secondAttribute="leading" id="Hco-4A-mGQ"/>
+                                        <constraint firstAttribute="trailing" secondItem="sWC-gV-Jil" secondAttribute="trailing" id="S9N-ma-Kpn"/>
+                                        <constraint firstAttribute="bottom" secondItem="sWC-gV-Jil" secondAttribute="bottom" id="SwC-Vl-JuZ"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YMG-ht-AdU" userLabel="Button Container">
-                                    <rect key="frame" x="0.0" y="374" width="300" height="50"/>
+                                    <rect key="frame" x="0.0" y="279" width="300" height="50"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6b-oT-zeV">
-                                            <rect key="frame" x="8" y="10" width="284" height="30"/>
+                                            <rect key="frame" x="8" y="8" width="284" height="34"/>
                                             <state key="normal" title="Button"/>
                                         </button>
                                     </subviews>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="JZv-Z5-qWf"/>
-                                        <constraint firstAttribute="trailing" secondItem="g6b-oT-zeV" secondAttribute="trailing" constant="8" id="PNQ-me-26f"/>
-                                        <constraint firstAttribute="bottom" secondItem="g6b-oT-zeV" secondAttribute="bottom" constant="10" id="Zk2-wn-QFk"/>
-                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="leading" secondItem="YMG-ht-AdU" secondAttribute="leading" constant="8" id="fPm-Vv-2hy"/>
-                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="top" secondItem="YMG-ht-AdU" secondAttribute="top" constant="10" id="oh1-oY-REt"/>
+                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="top" secondItem="YMG-ht-AdU" secondAttribute="top" constant="8" id="4eT-gg-WxG"/>
+                                        <constraint firstAttribute="bottom" secondItem="g6b-oT-zeV" secondAttribute="bottom" constant="8" id="HSB-tH-Kiw"/>
+                                        <constraint firstItem="g6b-oT-zeV" firstAttribute="leading" secondItem="YMG-ht-AdU" secondAttribute="leading" constant="8" id="YXv-fC-QmA"/>
+                                        <constraint firstAttribute="height" constant="50" id="g7P-lU-NPi"/>
+                                        <constraint firstAttribute="trailing" secondItem="g6b-oT-zeV" secondAttribute="trailing" constant="8" id="hS1-9z-d3f"/>
                                     </constraints>
                                 </view>
                             </subviews>
@@ -87,19 +108,18 @@
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
-                        <constraint firstItem="QSX-Xe-hid" firstAttribute="leading" secondItem="HSl-E2-Lx2" secondAttribute="leading" id="145-UB-IhO"/>
-                        <constraint firstAttribute="width" constant="300" id="5xq-tk-xuo"/>
-                        <constraint firstAttribute="height" constant="424" id="6oi-v9-CJg"/>
-                        <constraint firstAttribute="trailing" secondItem="QSX-Xe-hid" secondAttribute="trailing" id="GdS-cE-fBo"/>
-                        <constraint firstAttribute="bottom" secondItem="QSX-Xe-hid" secondAttribute="bottom" id="V2V-7f-13C"/>
-                        <constraint firstItem="QSX-Xe-hid" firstAttribute="top" secondItem="HSl-E2-Lx2" secondAttribute="top" id="ley-2M-VPK"/>
+                        <constraint firstAttribute="trailing" secondItem="QSX-Xe-hid" secondAttribute="trailing" id="MpS-AP-QgR"/>
+                        <constraint firstItem="QSX-Xe-hid" firstAttribute="top" secondItem="HSl-E2-Lx2" secondAttribute="top" constant="20" id="PfE-y6-82o"/>
+                        <constraint firstAttribute="width" constant="300" id="Qrp-77-Xl9"/>
+                        <constraint firstItem="QSX-Xe-hid" firstAttribute="leading" secondItem="HSl-E2-Lx2" secondAttribute="leading" id="WoT-rS-Ud8"/>
+                        <constraint firstAttribute="bottom" secondItem="QSX-Xe-hid" secondAttribute="bottom" constant="20" id="axe-87-pne"/>
                     </constraints>
                 </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="GbC-AJ-0QG"/>
-                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="Sjr-0c-vMZ"/>
+                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="VL4-LB-Dci"/>
+                <constraint firstItem="HSl-E2-Lx2" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="yFa-zq-OGL"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="110.49107142857143"/>


### PR DESCRIPTION
[PFCMP-0010] Network Failure View
Closes #98
***
## Description
Network Failure View Component

## Related Links
List related PRs against other branches:

List | link
------ | ------
User Story | [link]()
Figma | [link]()
Issue | [link]()

## Todos
- [ ] UI
- [ ] Coordinator
- [ ] Network
- [ ] Tests
- [ ] Documentation

## Screenshot / Video
<img width="325" alt="Screen Shot 2020-11-19 at 19 43 37" src="https://user-images.githubusercontent.com/44691206/99667833-87b6c180-2a9f-11eb-9e0e-2ee3c97f3137.png">

### UI Changes
UI related changes will be shown here (can be either screenshot or video format)

### Network Status
Network related changes will be shown here (screenshot of request status)

### Test Coverage
Test coverage result for designated changes will be shown here (screenshot of coverage)

## Notes
Additional notes that you have either technical debt, blocker, etc.
